### PR TITLE
[IT-3975] Deploy opentelemetry collector

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,12 +3,12 @@ import aws_cdk as cdk
 from os import environ
 from src.network_stack import NetworkStack
 from src.ecs_stack import EcsStack
-from src.service_stack import LoadBalancedServiceStack
+from src.service_stack import LoadBalancedServiceStack, ServiceStack
 from src.load_balancer_stack import LoadBalancerStack
-from src.service_props import ServiceProps
+from src.service_props import ServiceProps, ServiceSecret
 
 # get the environment and set environment specific variables
-VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
+VALID_ENVIRONMENTS = ["dev", "stage", "prod", "dev-sandbox"]
 environment = environ.get("ENV")
 match environment:
     case "prod":
@@ -32,10 +32,17 @@ match environment:
             "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/0e9682f6-3ffa-46fb-9671-b6349f5164d6",
             "TAGS": {"CostCenter": "NO PROGRAM / 000000"},
         }
+    case "dev-sandbox":
+        environment_variables = {
+            "VPC_CIDR": "10.254.192.0/24",
+            "FQDN": "dev.schematic.io",
+            "CERTIFICATE_ARN": "arn:aws:acm:us-east-1:631692904429:certificate/0e9682f6-3ffa-46fb-9671-b6349f5164d6",
+            "TAGS": {"CostCenter": "NO PROGRAM / 000000"},
+        }
     case _:
         valid_envs_str = ",".join(VALID_ENVIRONMENTS)
         raise SystemExit(
-            f"Must set environment variable `ENV` to one of {valid_envs_str}"
+            f"Must set environment variable `ENV` to one of {valid_envs_str}. Currently set to {environment}"
         )
 
 stack_name_prefix = f"schematic-{environment}"
@@ -68,26 +75,63 @@ load_balancer_stack = LoadBalancerStack(
     cdk_app, f"{stack_name_prefix}-load-balancer", network_stack.vpc
 )
 
+telemetry_environment_variables = {
+    "TRACING_EXPORT_FORMAT": "otlp",
+    "LOGGING_EXPORT_FORMAT": "otlp",
+    "TRACING_SERVICE_NAME": "schematic",
+    "LOGGING_SERVICE_NAME": "schematic",
+    "DEPLOYMENT_ENVIRONMENT": environment,
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector:4318",
+}
+
+
 app_service_props = ServiceProps(
-    "schematic-app",
-    443,
-    1024,
-    "ghcr.io/sage-bionetworks/schematic:v0.1.90-beta",
-    {},
-    f"{stack_name_prefix}-DockerFargateStack/{environment}/ecs",
+    container_name="schematic-app",
+    container_port=443,
+    container_memory=1024,
+    container_location="ghcr.io/sage-bionetworks/schematic:v0.1.90-beta",
+    container_env_vars=telemetry_environment_variables,
+    container_secrets=[
+        ServiceSecret(
+            secret_name=f"{stack_name_prefix}-DockerFargateStack/{environment}/ecs",
+            environment_key="SECRETS_MANAGER_SECRETS",
+        )
+    ],
 )
 
 app_service_stack = LoadBalancedServiceStack(
-    cdk_app,
-    f"{stack_name_prefix}-app",
-    network_stack.vpc,
-    ecs_stack.cluster,
-    app_service_props,
-    load_balancer_stack.alb,
-    environment_variables["CERTIFICATE_ARN"],
+    scope=cdk_app,
+    construct_id=f"{stack_name_prefix}-app",
+    vpc=network_stack.vpc,
+    cluster=ecs_stack.cluster,
+    props=app_service_props,
+    load_balancer=load_balancer_stack.alb,
+    certificate_arn=environment_variables["CERTIFICATE_ARN"],
     health_check_path="/health",
     health_check_interval=5,
 )
 
-# Generate stacks
+app_service_props_otel_collector = ServiceProps(
+    container_name="otel-collector",
+    container_port=4318,
+    container_memory=512,
+    container_location="otel/opentelemetry-collector-contrib:0.113.0",
+    container_env_vars={},
+    container_secrets=[
+        ServiceSecret(
+            secret_name=f"{stack_name_prefix}-DockerFargateStack/{environment}/opentelemetry-collector-configuration",
+            environment_key="CONFIG_CONTENT",
+        )
+    ],
+    container_command=["--config", "env:CONFIG_CONTENT"],
+)
+
+app_service_stack_otel_collector = ServiceStack(
+    scope=cdk_app,
+    construct_id=f"{stack_name_prefix}-otel-collector",
+    vpc=network_stack.vpc,
+    cluster=ecs_stack.cluster,
+    props=app_service_props_otel_collector,
+)
+
 cdk_app.synth()

--- a/src/service_props.py
+++ b/src/service_props.py
@@ -1,4 +1,24 @@
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
 CONTAINER_LOCATION_PATH_ID = "path://"
+
+
+@dataclass
+class ServiceSecret:
+    """
+    Holds onto configuration for the secrets to be used in the container.
+
+    Attributes:
+      secret_name: The name of the secret as stored in the AWS Secrets Manager
+      environment_key: The ARN of the secret as stored in the AWS Secrets Manager
+    """
+
+    secret_name: str
+    """The name of the secret as stored in the AWS Secrets Manager"""
+
+    environment_key: str
+    """The name to use for the environment variable within the container"""
 
 
 class ServiceProps:
@@ -13,7 +33,8 @@ class ServiceProps:
       supports docker registry references (i.e. ghcr.io/sage-bionetworks/schematic-thumbor:latest)
     container_env_vars: a json dictionary of environment variables to pass into the container
       i.e. {"EnvA": "EnvValueA", "EnvB": "EnvValueB"}
-    container_secret_name: the secret's name in the AWS secrets manager
+    container_secrets: List of `ServiceSecret` resources to pull from AWS secrets manager
+    container_command: Optional commands to run in the container
     """
 
     def __init__(
@@ -23,7 +44,8 @@ class ServiceProps:
         container_memory: int,
         container_location: str,
         container_env_vars: dict,
-        container_secret_name: str,
+        container_secrets: List[ServiceSecret],
+        container_command: Optional[Sequence[str]] = None,
     ) -> None:
         self.container_name = container_name
         self.container_port = container_port
@@ -34,4 +56,5 @@ class ServiceProps:
             )
         self.container_location = container_location
         self.container_env_vars = container_env_vars
-        self.container_secret_name = container_secret_name
+        self.container_secrets = container_secrets
+        self.container_command = container_command


### PR DESCRIPTION
Tasks before marking PR ready:

- [ ] Destroy CDK stacks for `dev-sandbox`
- [ ] Revert code for `dev-sandbox`

**Problem:**

1. An Opentelemetry collector needs to be deployed to ECS to support forwarding telemetry data for long-term storage and analysis.
2. A configuration file for the collector needs to be sourced from AWS secrets manager and injected into the Otel collector to configure the service.
3. Environment variables need to be updated in the schematic container to support configuring it to send telemetry data to the Otel collector.

**Solution:**

1. Deploying the otel collector contributor container to ECS. I had attempted to use the AWS otel collector, however, they do not support the Oauth2 extension that we will use to attached an Auth header on out-going requests: https://github.com/aws-observability/aws-otel-collector/issues/1492
2. Storing the otel config file in AWS Secret manager and injecting it into the Otel collector by overriding the docker CMD command on the container.
3. Setting environment variables on the schematic container to configure it sending telemetry data to the otel collector.

**Testing:**

1. TODO/IN-PROGRESS

**Additional notes:**

1. I had tried to get this extension on the collector working: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension - To configure container health checks, however, I couldn't get it working as every requests to the configured port/endpoint returned nothing. Because of this health checked I had configured were failing and killing the container. https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckv2extension is a replacement extension, however, it's not included in the built images yet - Once available I'd like to use this extension.